### PR TITLE
Warn user when prefixing an environment variable that doesn't exist

### DIFF
--- a/src/make-env-public.spec.ts
+++ b/src/make-env-public.spec.ts
@@ -78,6 +78,16 @@ describe('makeEnvPublic()', () => {
     );
   });
 
+  it('should warn when prefixing a variable that is not available in process.env', () => {
+    makeEnvPublic('FOO');
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      `${chalk.yellow(
+        `warn`
+      )}  - [next-runtime-env] - Skipped prefixing environment variable 'FOO'. Variable not in process.env.`
+    );
+  });
+
   it('should warn when the env var already starts with NEXT_PUBLIC_', () => {
     process.env.NEXT_PUBLIC_FOO = 'foo';
 

--- a/src/make-env-public.ts
+++ b/src/make-env-public.ts
@@ -1,7 +1,16 @@
 import * as log from './utils/log';
 
 function prefixKey(key: string) {
-  // Check if the key already is already public.
+  // Check if key is available in process.env.
+  if (!process.env[key]) {
+    log.warn(
+      `Skipped prefixing environment variable '${key}'. Variable not in process.env.`
+    );
+
+    return;
+  }
+
+  // Check if key is already public.
   if (/^NEXT_PUBLIC_/i.test(key)) {
     log.warn(`Environment variable '${key}' is already public.`);
   }


### PR DESCRIPTION
This PR:
- Shows a warning when a user tries to prefix an environment variable with `NEXT_PUBLIC_` when the environment variable isn't available in `process.env`.

This happens when developers comment out a variable from `.env` and re-run `pnpm dev`. 
This prevents polluting `__ENV.js` with variables that have the value of `undefined`.