### PR TITLE
Add component to render environment variables inline

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,8 @@
     "@types/eslint": "^8.44.2",
     "@types/jest": "^29.5.3",
     "@types/node": "^20.4.9",
+    "@types/react": "18.2.21",
+    "@types/react-test-renderer": "18.0.0",
     "@typescript-eslint/eslint-plugin": "^6.3.0",
     "@typescript-eslint/parser": "^6.3.0",
     "audit-ci": "^6.6.1",
@@ -48,8 +50,13 @@
     "eslint-plugin-simple-import-sort": "^10.0.0",
     "jest": "^29.6.2",
     "prettier": "^3.0.1",
+    "react": "^18.2.0",
+    "react-test-renderer": "^18.2.0",
     "semantic-release": "^21.0.7",
     "ts-jest": "^29.1.1",
     "typescript": "^5.1.6"
+  },
+  "peerDependencies": {
+    "react": "*"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,6 +19,12 @@ devDependencies:
   '@types/node':
     specifier: ^20.4.9
     version: 20.4.9
+  '@types/react':
+    specifier: 18.2.21
+    version: 18.2.21
+  '@types/react-test-renderer':
+    specifier: 18.0.0
+    version: 18.0.0
   '@typescript-eslint/eslint-plugin':
     specifier: ^6.3.0
     version: 6.3.0(@typescript-eslint/parser@6.3.0)(eslint@8.46.0)(typescript@5.1.6)
@@ -49,6 +55,12 @@ devDependencies:
   prettier:
     specifier: ^3.0.1
     version: 3.0.1
+  react:
+    specifier: ^18.2.0
+    version: 18.2.0
+  react-test-renderer:
+    specifier: ^18.2.0
+    version: 18.2.0(react@18.2.0)
   semantic-release:
     specifier: ^21.0.7
     version: 21.0.7
@@ -1078,6 +1090,28 @@ packages:
     resolution: {integrity: sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==}
     dev: true
 
+  /@types/prop-types@15.7.5:
+    resolution: {integrity: sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==}
+    dev: true
+
+  /@types/react-test-renderer@18.0.0:
+    resolution: {integrity: sha512-C7/5FBJ3g3sqUahguGi03O79b8afNeSD6T8/GU50oQrJCU0bVCCGQHaGKUbg2Ce8VQEEqTw8/HiS6lXHHdgkdQ==}
+    dependencies:
+      '@types/react': 18.2.21
+    dev: true
+
+  /@types/react@18.2.21:
+    resolution: {integrity: sha512-neFKG/sBAwGxHgXiIxnbm3/AAVQ/cMRS93hvBpg8xYRbeQSPVABp9U2bRnPf0iI4+Ucdv3plSxKK+3CW2ENJxA==}
+    dependencies:
+      '@types/prop-types': 15.7.5
+      '@types/scheduler': 0.16.3
+      csstype: 3.1.2
+    dev: true
+
+  /@types/scheduler@0.16.3:
+    resolution: {integrity: sha512-5cJ8CB4yAx7BH1oMvdU0Jh9lrEXyPkar6F9G/ERswkCuvP4KQZfZkSjcMbAICCpQTN4OuZn8tz0HiKv9TGZgrQ==}
+    dev: true
+
   /@types/semver@7.5.0:
     resolution: {integrity: sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==}
     dev: true
@@ -1808,6 +1842,10 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       type-fest: 1.4.0
+    dev: true
+
+  /csstype@3.1.2:
+    resolution: {integrity: sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==}
     dev: true
 
   /dateformat@3.0.3:
@@ -3735,6 +3773,13 @@ packages:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
     dev: true
 
+  /loose-envify@1.4.0:
+    resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
+    hasBin: true
+    dependencies:
+      js-tokens: 4.0.0
+    dev: true
+
   /lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
     dependencies:
@@ -4049,6 +4094,11 @@ packages:
       - validate-npm-package-name
       - which
       - write-file-atomic
+
+  /object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+    dev: true
 
   /object-inspect@1.12.3:
     resolution: {integrity: sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==}
@@ -4432,6 +4482,34 @@ packages:
     resolution: {integrity: sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==}
     dev: true
 
+  /react-shallow-renderer@16.15.0(react@18.2.0):
+    resolution: {integrity: sha512-oScf2FqQ9LFVQgA73vr86xl2NaOIX73rh+YFqcOp68CWj56tSfgtGKrEbyhCj0rSijyG9M1CYprTh39fBi5hzA==}
+    peerDependencies:
+      react: ^16.0.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      object-assign: 4.1.1
+      react: 18.2.0
+      react-is: 18.2.0
+    dev: true
+
+  /react-test-renderer@18.2.0(react@18.2.0):
+    resolution: {integrity: sha512-JWD+aQ0lh2gvh4NM3bBM42Kx+XybOxCpgYK7F8ugAlpaTSnWsX+39Z4XkOykGZAHrjwwTZT3x3KxswVWxHPUqA==}
+    peerDependencies:
+      react: ^18.2.0
+    dependencies:
+      react: 18.2.0
+      react-is: 18.2.0
+      react-shallow-renderer: 16.15.0(react@18.2.0)
+      scheduler: 0.23.0
+    dev: true
+
+  /react@18.2.0:
+    resolution: {integrity: sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      loose-envify: 1.4.0
+    dev: true
+
   /read-pkg-up@10.0.0:
     resolution: {integrity: sha512-jgmKiS//w2Zs+YbX039CorlkOp8FIVbSAN8r8GJHDsGlmNPXo+VeHkqAwCiQVTTx5/LwLZTcEw59z3DvcLbr0g==}
     engines: {node: '>=16'}
@@ -4611,6 +4689,12 @@ packages:
       call-bind: 1.0.2
       get-intrinsic: 1.2.1
       is-regex: 1.1.4
+    dev: true
+
+  /scheduler@0.23.0:
+    resolution: {integrity: sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==}
+    dependencies:
+      loose-envify: 1.4.0
     dev: true
 
   /semantic-release@21.0.7:

--- a/src/components/inline-runtime-env.spec.ts
+++ b/src/components/inline-runtime-env.spec.ts
@@ -1,0 +1,26 @@
+import TestRenderer from 'react-test-renderer';
+
+import { getPublicEnv } from '../helpers/get-public-env';
+import { InlineRuntimeEnv } from './inline-env';
+
+jest.mock('../helpers/get-public-env', () => ({
+  getPublicEnv: jest.fn().mockReturnValue({
+    NEXT_PUBLIC_FOO: 'foo',
+    NEXT_PUBLIC_BAZ: 'baz',
+  }),
+}));
+
+describe('InlineRuntimeEnv', () => {
+  it('renders a script tag with the env variables', () => {
+    const renderer = TestRenderer.create(InlineRuntimeEnv);
+
+    expect(renderer.root.findByType('script').props).toEqual({
+      dangerouslySetInnerHTML: {
+        __html:
+          'window.__ENV = {"NEXT_PUBLIC_FOO":"foo","NEXT_PUBLIC_BAZ":"baz"};',
+      },
+    });
+
+    expect(getPublicEnv).toBeCalledTimes(1);
+  });
+});

--- a/src/components/inline-runtime-env.ts
+++ b/src/components/inline-runtime-env.ts
@@ -1,0 +1,9 @@
+import React from 'react';
+
+import { getPublicEnv } from '../helpers/get-public-env';
+
+export const InlineRuntimeEnv = React.createElement('script', {
+  dangerouslySetInnerHTML: {
+    __html: `window.__ENV = ${JSON.stringify(getPublicEnv())};`,
+  },
+});


### PR DESCRIPTION
This is an experiment that's I'm currently using in a project of mine. This allows users to remove the additional request for the `__ENV.js` file, and instead have the environment variables embedded in the source of the page. 

Additionally, to bypass CSRF policies the script tag could be implemented with a custom type, and then the `env()` function could extract the inner content of the tag and pass that through `JSON.parse` to populate the global `__ENV` object instead. This I haven't implemented yet tho.

Let me know what you think, and maybe I don't know about a scenario where this wouldn't work? 

Nb. I think this won't work for static builds.