### PR TITLE
feat(makePublic): Enable using empty process.env based on options

### DIFF
--- a/src/utils/make-env-public.spec.ts
+++ b/src/utils/make-env-public.spec.ts
@@ -70,7 +70,14 @@ describe('makeEnvPublic()', () => {
     );
   });
 
-  it('should warn when prefixing a variable that is not available in process.env', () => {
+  it('should warn when prefixing a variable that is not available in process.env and default options', () => {
+    makeEnvPublic('FOO', {skipNonExistingVar: false});
+
+    expect(process.env.FOO).toEqual("");
+    expect(process.env.NEXT_PUBLIC_FOO).toEqual("");
+  });
+
+  it('should prefixi a variable that is not available in process.env if skipNonExistingVar option is false', () => {
     makeEnvPublic('FOO');
 
     expect(warnMock).toHaveBeenCalledWith(

--- a/src/utils/make-env-public.ts
+++ b/src/utils/make-env-public.ts
@@ -1,16 +1,23 @@
 import { event, LogOptions, warn } from '../helpers/log';
 
-export interface MakeEnvPublicOptions extends LogOptions {}
+export interface MakeEnvPublicOptions extends LogOptions {
+  skipNonExistingVar?: boolean
+}
 
 function prefixKey(key: string, options?: MakeEnvPublicOptions) {
+  const {skipNonExistingVar = true} = options || {};
   // Check if key is available in process.env.
   if (!process.env[key]) {
-    warn(
-      `Skipped prefixing environment variable '${key}'. Variable not in process.env`,
-      options,
-    );
+    if (skipNonExistingVar) {
+      warn(
+        `Skipped prefixing environment variable '${key}'. Variable not in process.env`,
+        options,
+      );
+  
+      return;
+    }
 
-    return;
+    process.env[key] = ''
   }
 
   // Check if key is already public.
@@ -20,7 +27,7 @@ function prefixKey(key: string, options?: MakeEnvPublicOptions) {
 
   const prefixedKey = `NEXT_PUBLIC_${key}`;
 
-  process.env[prefixedKey] = process.env[key];
+  process.env[prefixedKey] = process.env[key] || "";
 
   // eslint-disable-next-line no-console
   event(`Prefixed environment variable '${key}'`, options);
@@ -38,6 +45,9 @@ function prefixKey(key: string, options?: MakeEnvPublicOptions) {
  * // Make multiple variables public.
  * makeEnvPublic(['FOO', 'BAR', 'BAZ']);
  *
+ * // Enable prefixing vars not present on process.env
+ * makeEnvPublic('FOO', { skipNonExistingVar: false });
+ * 
  * // Disable logging.
  * makeEnvPublic('FOO', { logLevel: 'silent' });
  *


### PR DESCRIPTION
This enables prefixing variables even if you don't have a .env on build time. 