### PR TITLE
feat: ✨ add options to use Next Script Component or a regular script tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,6 @@ jobs:
           JEST_JUNIT_CLASSNAME: '{filepath}'
 
       - name: Upload code coverage
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/src/script/env-script.spec.tsx
+++ b/src/script/env-script.spec.tsx
@@ -45,6 +45,46 @@ describe('EnvScript', () => {
     expect(document.querySelector('script')).not.toHaveAttribute('nonce');
   });
 
+  it('should accept Next.js Script tag props', () => {
+    const env = { NODE_ENV: 'test', API_URL: 'http://localhost:3000' };
+    const nonce = 'test-nonce-xyz';
+    const id = 'text-id-abc';
+
+    render(
+      <EnvScript
+        env={env}
+        nonce={nonce}
+        nextScriptComponentProps={{
+          strategy: 'afterInteractive',
+          id,
+        }}
+      />,
+    );
+
+    expect(document.querySelector('script')).toHaveAttribute('nonce', nonce);
+    expect(document.querySelector('script')).toHaveAttribute('id', id);
+    expect(document.querySelector('script')?.textContent).toBe(
+      `window['__ENV'] = ${JSON.stringify(env)}`,
+    );
+  });
+
+  it('should not have Next.js Script props when a regular script tag is used', () => {
+    const env = { NODE_ENV: 'test', API_URL: 'http://localhost:3000' };
+    const id = 'text-id-abc';
+
+    render(
+      <EnvScript
+        env={env}
+        withNextScriptComponent={false}
+        nextScriptComponentProps={{
+          id,
+        }}
+      />,
+    );
+
+    expect(document.querySelector('script')).not.toHaveAttribute('id', id);
+  });
+
   it.todo(
     'should get the nonce from the headers when the headerKey is provided',
   );

--- a/src/script/env-script.tsx
+++ b/src/script/env-script.tsx
@@ -1,6 +1,6 @@
 // XXX: Blocked by https://github.com/vercel/next.js/pull/58129
 // import { headers } from 'next/headers';
-import Script from 'next/script';
+import Script, { ScriptProps } from 'next/script';
 import { type FC } from 'react';
 
 import { type NonceConfig } from '../typings/nonce';
@@ -10,6 +10,8 @@ import { PUBLIC_ENV_KEY } from './constants';
 type EnvScriptProps = {
   env: ProcessEnv;
   nonce?: string | NonceConfig;
+  withNextScriptComponent?: boolean;
+  nextScriptComponentProps?: ScriptProps;
 };
 
 /**
@@ -23,7 +25,12 @@ type EnvScriptProps = {
  * </head>
  * ```
  */
-export const EnvScript: FC<EnvScriptProps> = ({ env, nonce }) => {
+export const EnvScript: FC<EnvScriptProps> = ({
+  env,
+  nonce,
+  withNextScriptComponent = true,
+  nextScriptComponentProps = { strategy: 'beforeInteractive' },
+}) => {
   let nonceString: string | undefined;
 
   // XXX: Blocked by https://github.com/vercel/next.js/pull/58129
@@ -36,13 +43,23 @@ export const EnvScript: FC<EnvScriptProps> = ({ env, nonce }) => {
     nonceString = nonce;
   }
 
+  const html = {
+    __html: `window['${PUBLIC_ENV_KEY}'] = ${JSON.stringify(env)}`,
+  };
+
+  // You can opt to use a regular "<script>" tag instead of Next.js' Script Component.
+  // Note: When using Sentry, sentry.client.config.ts might run after the Next.js <Script> component, even when the strategy is "beforeInteractive"
+  // This results in the runtime environments being undefined and the Sentry client config initialized without the correct configuration.
+  if (!withNextScriptComponent) {
+    return <script nonce={nonceString} dangerouslySetInnerHTML={html} />;
+  }
+
+  // Use Next.js Script Component by default
   return (
     <Script
-      strategy="beforeInteractive"
+      {...nextScriptComponentProps}
       nonce={nonceString}
-      dangerouslySetInnerHTML={{
-        __html: `window['${PUBLIC_ENV_KEY}'] = ${JSON.stringify(env)}`,
-      }}
+      dangerouslySetInnerHTML={html}
     />
   );
 };


### PR DESCRIPTION
When using Sentry and `next-runtime-env`, we ran into a race condition with Sentry's client side configuration `sentry.client.config.ts`:

1. A user visits our application
2. The webpage loads
3. Sentry's `sentry.client.config.ts` runs before our `<PublicEnvScript />`, and looks for `env('DEPLOYMENT_ENV')`, but these values are `undefined`
3. Next.js Script component defaults to `"beforeInteractive"` and adds the runtime variables to `window.__ENV` _after_ Sentry's init.

For now, the quickest solution is to enable users to use both Next.js Script Component and a regular script tag.