### PR TITLE
fix: add suppressHydrationWarning when using nonce and disableNextScript

### DIFF
--- a/src/script/env-script.tsx
+++ b/src/script/env-script.tsx
@@ -51,7 +51,16 @@ export const EnvScript: FC<EnvScriptProps> = ({
   // Note: When using Sentry, sentry.client.config.ts might run after the Next.js <Script> component, even when the strategy is "beforeInteractive"
   // This results in the runtime environments being undefined and the Sentry client config initialized without the correct configuration.
   if (disableNextScript) {
-    return <script nonce={nonceString} dangerouslySetInnerHTML={innerHTML} />;
+    // Set suppressHydrationWarning on the vanilla script tag if nonce is being used, as React will
+    // throw a ssr hydration error otherwise. This is because the browser removes the nonce from the
+    // DOM before the hydration check takes place, leading to a mismatch. This can be safely ignored.
+    return (
+      <script
+        suppressHydrationWarning={!!nonceString}
+        nonce={nonceString}
+        dangerouslySetInnerHTML={innerHTML}
+      />
+    );
   }
 
   // Use Next.js Script Component by default


### PR DESCRIPTION
### The problem
When using disableNextScript and a nonce at the same time, React complains about a hydration mismatch between a nonce parameter with some value on the server, and a nonce value of "" in the client.
  
 ### The cause
Nonces are removed by the browser from DOM elements to prevent them from being exposed to client side code. This happens before React hydrates the page, so it causes a mismatch.
  
 ### The fix
Set suppressHydrationWarning on the vanilla script tag if nonce is being used.