### PR TITLE
fix: prevent non-public env vars from leaking into client HTML via SSR

### DIFF
--- a/examples/with-app-router-script/src/app/leak-test/page.tsx
+++ b/examples/with-app-router-script/src/app/leak-test/page.tsx
@@ -1,0 +1,12 @@
+'use client';
+
+import { env } from 'next-runtime-env';
+
+export default function LeakTest() {
+  return (
+    <main>
+      <p>HOME: {env('HOME')}</p>
+      <p>PUBLIC: {env('NEXT_PUBLIC_FOO')}</p>
+    </main>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,12 @@
   "version": "0.0.0-development",
   "description": "Next.js Runtime Environment Configuration - Populates your environment at runtime rather than build time.",
   "main": "build/index.js",
+  "exports": {
+    ".": {
+      "react-server": "./build/index.server.js",
+      "default": "./build/index.js"
+    }
+  },
   "scripts": {
     "lint": "eslint ./src",
     "lint:fix": "pnpm lint --fix",

--- a/src/index.server.ts
+++ b/src/index.server.ts
@@ -1,0 +1,6 @@
+/* istanbul ignore file */
+
+// Re-export everything from the default entry, then override env()
+// with the server version that allows access to all env vars.
+export * from './index';
+export { env } from './script/env.server';

--- a/src/script/env.server.spec.ts
+++ b/src/script/env.server.spec.ts
@@ -1,0 +1,28 @@
+import { env } from './env.server';
+
+jest.mock('next/cache', () => ({
+  unstable_noStore: jest.fn(),
+}));
+
+describe('env() server version', () => {
+  afterEach(() => {
+    delete process.env.FOO;
+    delete process.env.NEXT_PUBLIC_BAR;
+  });
+
+  it('should return any env var', () => {
+    process.env.FOO = 'secret';
+
+    expect(env('FOO')).toEqual('secret');
+  });
+
+  it('should return public env vars too', () => {
+    process.env.NEXT_PUBLIC_BAR = 'public';
+
+    expect(env('NEXT_PUBLIC_BAR')).toEqual('public');
+  });
+
+  it('should return undefined for missing vars', () => {
+    expect(env('DOES_NOT_EXIST')).toEqual(undefined);
+  });
+});

--- a/src/script/env.server.ts
+++ b/src/script/env.server.ts
@@ -1,0 +1,11 @@
+import { unstable_noStore as noStore } from 'next/cache';
+
+/**
+ * Server Component version: reads any env var from process.env.
+ * Safe because Server Component output never leaks into client HTML.
+ */
+export function env(key: string): string | undefined {
+  noStore();
+
+  return process.env[key];
+}

--- a/src/script/env.spec.ts
+++ b/src/script/env.spec.ts
@@ -1,20 +1,21 @@
 import { env } from './env';
 
-describe('env()', () => {
+describe('env() client version', () => {
   afterEach(() => {
     delete process.env.FOO;
+    delete process.env.NEXT_PUBLIC_FOO;
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     global.window = undefined as any;
   });
 
-  it('should return a value from the server', () => {
-    process.env.FOO = 'foo';
+  it('should return a public var from the server (SSR)', () => {
+    process.env.NEXT_PUBLIC_FOO = 'foo';
 
-    expect(env('FOO')).toEqual('foo');
+    expect(env('NEXT_PUBLIC_FOO')).toEqual('foo');
   });
 
-  it('should return a value from the browser', () => {
+  it('should return a public var from the browser', () => {
     Object.defineProperty(global, 'window', {
       value: {
         __ENV: {
@@ -27,11 +28,32 @@ describe('env()', () => {
     expect(env('NEXT_PUBLIC_FOO')).toEqual('foo');
   });
 
-  it('should return undefined when variable does not exist on the server', () => {
-    expect(env('BAM_BAM')).toEqual(undefined);
+  it('should throw for non-public var on the server (SSR)', () => {
+    process.env.FOO = 'secret';
+
+    expect(() => env('FOO')).toThrow(
+      /not public and cannot be accessed from a Client Component/,
+    );
   });
 
-  it('should return undefined when variable does not exist in the browser', () => {
+  it('should throw for non-public var in the browser', () => {
+    Object.defineProperty(global, 'window', {
+      value: {
+        __ENV: {},
+      },
+      writable: true,
+    });
+
+    expect(() => env('FOO')).toThrow(
+      /not public and cannot be accessed from a Client Component/,
+    );
+  });
+
+  it('should return undefined when public var does not exist on the server', () => {
+    expect(env('NEXT_PUBLIC_MISSING')).toEqual(undefined);
+  });
+
+  it('should return undefined when public var does not exist in the browser', () => {
     Object.defineProperty(global, 'window', {
       value: {
         __ENV: {
@@ -42,20 +64,5 @@ describe('env()', () => {
     });
 
     expect(env('NEXT_PUBLIC_BAR')).toEqual(undefined);
-  });
-
-  it('should throw when trying to access a non public variable in the browser', () => {
-    Object.defineProperty(global, 'window', {
-      value: {
-        __ENV: {
-          NEXT_PUBLIC_FOO: 'foo',
-        },
-      },
-      writable: true,
-    });
-
-    expect(() => env('BAM_BAM')).toThrow(
-      "Environment variable 'BAM_BAM' is not public and cannot be accessed in the browser.",
-    );
   });
 });

--- a/src/script/env.ts
+++ b/src/script/env.ts
@@ -1,29 +1,22 @@
-import { unstable_noStore as noStore } from 'next/cache';
-
 import { isBrowser } from '../helpers/is-browser';
 import { PUBLIC_ENV_KEY } from './constants';
 
 /**
- * Reads a safe environment variable from the browser or any environment
- * variable from the server (process.env).
- *
- * Usage:
- * ```ts
- * const API_URL = env('NEXT_PUBLIC_API_URL');
- * ```
+ * Client Component version: only allows NEXT_PUBLIC_* variables.
+ * This runs both in the browser and during SSR of client components.
+ * Blocking non-public vars prevents secrets from leaking into HTML.
  */
 export function env(key: string): string | undefined {
-  if (isBrowser()) {
-    if (!key.startsWith('NEXT_PUBLIC_')) {
-      throw new Error(
-        `Environment variable '${key}' is not public and cannot be accessed in the browser.`,
-      );
-    }
-
-    return window[PUBLIC_ENV_KEY][key];
+  if (!key.startsWith('NEXT_PUBLIC_')) {
+    throw new Error(
+      `Environment variable '${key}' is not public and cannot be accessed from a Client Component. ` +
+      `Use process.env['${key}'] directly in a Server Component instead.`,
+    );
   }
 
-  noStore();
+  if (isBrowser()) {
+    return window[PUBLIC_ENV_KEY][key];
+  }
 
   return process.env[key];
 }


### PR DESCRIPTION
Fixes #187

## Problem

`env()` called in a `"use client"` component leaks server-side env vars into HTML during SSR. The `NEXT_PUBLIC_` check only runs in the browser, but client components also render on the server for the initial HTML response.

For example:
```tsx
"use client";
import { env } from 'next-runtime-env';
export default function Page() {
  return <pre>{env("HOME")}</pre>; // value ends up in page source
}
```

## Solution

Use the `react-server` exports condition in package.json to serve different `env()` implementations depending on the bundler context:

- **Server Components** (react-server condition): unrestricted access to all env vars. Safe because Server Component output never reaches client HTML.
- **Client Components** (default condition): only `NEXT_PUBLIC_*` allowed, even during SSR. Throws with a helpful error message for non-public vars.

Same `import { env }` statement, different behavior, decided at build time by the bundler. This is the same pattern used by the `server-only` package from the React team.

## Changes

- `env.ts` -- moved `NEXT_PUBLIC_` check before `isBrowser()` so it blocks during SSR too
- `env.server.ts` -- new file, server version without prefix restriction
- `index.server.ts` -- server entry point, re-exports everything from index + overrides env
- `package.json` -- added `exports` with `react-server` condition
- Updated tests for both versions

## Breaking changes

- `env("SECRET")` in `"use client"` files will now throw. This was a security bug, not a feature. Error message suggests using `process.env` directly in Server Components.
- No breaking change for Server Components.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated server entrypoint and a client example page for App Router usage
  * Improved environment-variable handling with clearer client/server separation and server-specific env access

* **Tests**
  * Added and updated tests to validate server-side env behavior and client/server access rules
<!-- end of auto-generated comment: release notes by coderabbit.ai -->